### PR TITLE
feat: add Docker extension to devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,10 @@
 {
-    "image": "ghcr.io/joshyorko/joshyorko_devcontainer:latest"
+    "image": "ghcr.io/joshyorko/joshyorko_devcontainer:latest",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-azuretools.vscode-docker"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
This PR adds the Docker extension to the VS Code devcontainer configuration.

Changes:
- Added Docker extension (`ms-azuretools.vscode-docker`) to devcontainer.json
- Updated customizations section to include VS Code extensions

This will help with Docker container management directly from VS Code.